### PR TITLE
Ensure .map gets evaluated

### DIFF
--- a/lib/Concurrent/File/Find.pm6
+++ b/lib/Concurrent/File/Find.pm6
@@ -113,7 +113,7 @@ sub find (
                 CATCH { when X::Channel::SendOnClosed { last } }
                 $channel.send(.&return-type) if all @tests».(.IO);
             }
-            .IO.dir().sort({.e && .f}).map(&?BLOCK) if $recursive && .&max-depth && all @dir-tests».(.IO)
+            .IO.dir().sort({.e && .f}).map(&?BLOCK).eager if $recursive && .&max-depth && all @dir-tests».(.IO)
         }
         LEAVE $channel.close;
     }


### PR DESCRIPTION
Depending on how https://rt.perl.org/Ticket/Display.html?id=131593 gets
resolved, this module may end up being broken, due to map not being
revaluated eagerly.

Fix by explicitly requesting eager evaluation.