### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ find(%*ENV<HOME>
     , :file # return file paths
     , :!directory # don't return directory paths
     , :symlink # return symlink paths
-    , :max-depth(5) # but not deeper then 5 directories deep
+    , :max-depth(5) # but not deeper than 5 directories deep
     , :follow-symlink # follow symlinks (no loop detection yet)
     , :keep-going # on error (no access, stale symlink, etc.), keep going
     , :quiet # don't report errors on STDERR


### PR DESCRIPTION
There is a minuscule (1-character) typo in [README.md](https://github.com/gfldex/perl6-concurrent-file-find/blob/master/README.md): it should be 

> not deeper **than** 5 directories